### PR TITLE
Update config.pp to use httpS for default_url_pattern

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@
 class mailman::config inherits mailman::params {
   $default_url_host         = $mailman::http_hostname
   $default_email_host       = $mailman::default_email_host
-  $default_url_pattern      = 'http://%s/mailman/'
+  $default_url_pattern      = 'https://%s/mailman/'
   $mailman_site_list        = $mailman::mailman_site_list
   $language                 = $mailman::language
   $mta                      = $mailman::mta


### PR DESCRIPTION
The documented way to upgrade to HTTPS as described in the [mailman wiki](https://wiki.list.org/DOC/4.27%20Securing%20Mailman%27s%20web%20GUI%20by%20using%20Secure%20HTTP-SSL%20%28HTTPS%29) is to change default_url_pattern to 'https://%s/mailman/'.